### PR TITLE
Catch exception when a command throws an unhandled exception

### DIFF
--- a/ShiftOS.WinForms/Resources/strings_en.txt
+++ b/ShiftOS.WinForms/Resources/strings_en.txt
@@ -176,6 +176,7 @@ If a system file is deleted by the virus scanner, it will be replaced.",
 	"{COMMAND_DEV_MULTARG_DESCRIPTION}":"A command which requiers multiple arguments",
 
 	"{ERR_COMMAND_NOT_FOUND}":"Command not found.",
+	"{ERROR_EXCEPTION_THROWN_IN_METHOD}":"An error occurred within the command. Error details:",
 	"{MUD_ERROR}":"MUD error",
 	
 	"{PROLOGUE_NO_USER_DETECTED}":"No user detected. Please enter a username.",

--- a/ShiftOS_TheReturn/Commands.cs
+++ b/ShiftOS_TheReturn/Commands.cs
@@ -286,7 +286,6 @@ namespace ShiftOS.Engine {
             }
         }
 
-
         [Command("help", "{COMMAND_HELP_USAGE}", "{COMMAND_HELP_DESCRIPTION}")]
         public static bool Help() {
             var asm = Assembly.GetExecutingAssembly();

--- a/ShiftOS_TheReturn/Resources/strings_en.txt
+++ b/ShiftOS_TheReturn/Resources/strings_en.txt
@@ -175,6 +175,7 @@ If a system file is deleted by the virus scanner, it will be replaced.",
 	"{COMMAND_DEV_MULTARG_DESCRIPTION}":"A command which requiers multiple arguments",
 
 	"{ERR_COMMAND_NOT_FOUND}":"Command not found.",
+	"{ERROR_EXCEPTION_THROWN_IN_METHOD}":"An error occurred within the command. Error details:",
 	"{MUD_ERROR}":"MUD error",
 	
 	"{PROLOGUE_NO_USER_DETECTED}":"No user detected. Please enter a username.",

--- a/ShiftOS_TheReturn/TerminalBackend.cs
+++ b/ShiftOS_TheReturn/TerminalBackend.cs
@@ -210,6 +210,13 @@ namespace ShiftOS.Engine
                                                             {
                                                                 return (bool)method.Invoke(null, new[] { args });
                                                             }
+                                                            catch (TargetInvocationException e)
+                                                            {
+                                                                Console.WriteLine(Localization.Parse("{ERROR_EXCEPTION_THROWN_IN_METHOD}"));
+                                                                Console.WriteLine(e.InnerException.Message);
+                                                                Console.WriteLine(e.InnerException.StackTrace);
+                                                                return true;
+                                                            }
                                                             catch
                                                             {
                                                                 return (bool)method.Invoke(null, new object[] { });


### PR DESCRIPTION
# Pull Request

## What did you change
Added an exception handler for commands, just in case they throw an exception

## Benefits
ShiftOS should no longer crash because of badly written code inside any new commands, and instead print errors to the console.

## Remarks
By Default, Visual Studio is configured to break when an exception is thrown inside an invoked method. Therefore, Visual Studio will still break when an exception is thrown. To change this behaviour, when ShiftOS crashes because an exception was thrown inside a command, go to Visual Studio, uncheck "Break when this exception is thrown" and click "Continue." You should only have to do this once. 

When ShiftOS is not being debugged, the exception handler should immediately take effect rather than crashing ShiftOS

EDIT: Localisation issue should be fixed now. Thanks Michael :)
<strike>Currently, there seems to be an issue with localisation, and instead of printing ```An error occurred within the command. Error details:``` to the console, ShiftOS prints ```{ERROR_EXCEPTION_THROWN_IN_METHOD}```</strike>