### PR TITLE
VS failed to save

### DIFF
--- a/ShiftOS_TheReturn/Resources/Shiftorium.txt
+++ b/ShiftOS_TheReturn/Resources/Shiftorium.txt
@@ -29,6 +29,11 @@
 		Description: "Sometimes it's useful to have a list of windows that are open on your system so you can easily switch between them.",
 		Dependencies: "desktop;wm_unlimited_windows"
 	},
+	{ 
+		Name: "Audio volume",
+		Cost: 80,
+		Description: "Allows you to change the system music volume"
+	},
 	{
 		Name: "AL Skin Loader",
 		Cost: 125,


### PR DESCRIPTION
For some reason Visual Studio didn't save *all* my changes. This caused my previous PR to make audio commands require a shiftorium upgrade that didn't exist. This is now fixed.