### PR TITLE
ReflectMan Saves The Day..............

### DIFF
--- a/ShiftOS.WinForms/Applications/IconManager.cs
+++ b/ShiftOS.WinForms/Applications/IconManager.cs
@@ -92,70 +92,51 @@ namespace ShiftOS.WinForms.Applications
         {
             flbody.Controls.Clear(); //Clear the icon list.
 
-            List<Type> types = new List<Type>();
+            Type[] types = Array.FindAll(ReflectMan.Types, x => x.GetCustomAttributes(false).FirstOrDefault(y => y is DefaultIconAttribute) != null);
 
-            foreach(var exe in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
+            pageCount = types.GetPageCount(pageSize);
+
+            foreach (var type in Array.FindAll(types.GetItemsOnPage(currentPage, pageSize), t => Shiftorium.UpgradeAttributesUnlocked(t)))
             {
-                if(exe.ToLower().EndsWith(".exe") || exe.ToLower().EndsWith(".dll"))
+                var pnl = new Panel();
+                pnl.Height = 30;
+                pnl.Width = flbody.Width - 15;
+                flbody.Controls.Add(pnl);
+                pnl.Show();
+                var pic = new PictureBox();
+                pic.SizeMode = PictureBoxSizeMode.StretchImage;
+                pic.Size = new Size(24, 24);
+                pic.Image = GetIcon(type.Name);
+                pnl.Controls.Add(pic);
+                pic.Left = 5;
+                pic.Top = (pnl.Height - pic.Height) / 2;
+                pic.Show();
+                var lbl = new Label();
+                lbl.Tag = "header3";
+                lbl.AutoSize = true;
+                lbl.Text = NameChangerBackend.GetNameRaw(type);
+                ControlManager.SetupControl(lbl);
+                pnl.Controls.Add(lbl);
+                lbl.CenterParent();
+                lbl.Show();
+                var btn = new Button();
+                btn.Text = "Change...";
+                btn.AutoSize = true;
+                btn.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+                pnl.Controls.Add(btn);
+                btn.Left = (pnl.Width - btn.Width) - 5;
+                btn.Top = (pnl.Height - btn.Height) / 2;
+                btn.Click += (o, a) =>
                 {
-                    try
+                    var gfp = new GraphicPicker(pic.Image, lbl.Text + " icon", ImageLayout.Stretch, (raw, img, layout) =>
                     {
-                        var asm = Assembly.LoadFile(exe);
-
-                        var typeList = asm.GetTypes().Where(x => x.GetCustomAttributes(false).FirstOrDefault(y => y is DefaultIconAttribute) != null);
-                        types.AddRange(typeList);
-
-                    }
-                    catch { }
-                }
-            }
-
-            pageCount = types.ToArray().GetPageCount(pageSize);
-
-            foreach (var type in types.ToArray().GetItemsOnPage(currentPage, pageSize))
-            {
-                if (Shiftorium.UpgradeAttributesUnlocked(type))
-                {
-                    var pnl = new Panel();
-                    pnl.Height = 30;
-                    pnl.Width = flbody.Width - 15;
-                    flbody.Controls.Add(pnl);
-                    pnl.Show();
-                    var pic = new PictureBox();
-                    pic.SizeMode = PictureBoxSizeMode.StretchImage;
-                    pic.Size = new Size(24, 24);
-                    pic.Image = GetIcon(type.Name);
-                    pnl.Controls.Add(pic);
-                    pic.Left = 5;
-                    pic.Top = (pnl.Height - pic.Height) / 2;
-                    pic.Show();
-                    var lbl = new Label();
-                    lbl.Tag = "header3";
-                    lbl.AutoSize = true;
-                    lbl.Text = NameChangerBackend.GetNameRaw(type);
-                    ControlManager.SetupControl(lbl);
-                    pnl.Controls.Add(lbl);
-                    lbl.CenterParent();
-                    lbl.Show();
-                    var btn = new Button();
-                    btn.Text = "Change...";
-                    btn.AutoSize = true;
-                    btn.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-                    pnl.Controls.Add(btn);
-                    btn.Left = (pnl.Width - btn.Width) - 5;
-                    btn.Top = (pnl.Height - btn.Height) / 2;
-                    btn.Click += (o, a) =>
-                    {
-                        var gfp = new GraphicPicker(pic.Image, lbl.Text + " icon", ImageLayout.Stretch, (raw, img, layout) =>
-                        {
-                            pic.Image = img;
-                            SetIcon(type.Name, raw);
-                        });
-                        AppearanceManager.SetupDialog(gfp);
-                    };
-                    btn.Show();
-                    ControlManager.SetupControls(pnl);
-                }
+                        pic.Image = img;
+                        SetIcon(type.Name, raw);
+                    });
+                    AppearanceManager.SetupDialog(gfp);
+                };
+                btn.Show();
+                ControlManager.SetupControls(pnl);
             }
 
             btnnext.Visible = (currentPage < pageCount - 1);

--- a/ShiftOS.WinForms/Applications/ShiftoriumFrontend.cs
+++ b/ShiftOS.WinForms/Applications/ShiftoriumFrontend.cs
@@ -114,8 +114,12 @@ namespace ShiftOS.WinForms.Applications
 
         private void SetList()
         {
-            lbnoupgrades.Hide();
             lbupgrades.Items.Clear();
+            if (upgrades.Length == 0)
+                return;
+            lbnoupgrades.Hide();
+            if (CategoryId > upgrades.Length)
+                CategoryId = 0;
             try
             {
                 lbupgrades.Items.AddRange(upgrades[CategoryId].Keys.ToArray());
@@ -250,6 +254,7 @@ namespace ShiftOS.WinForms.Applications
 
         private void moveCat(short direction) // direction is -1 to move backwards or 1 to move forwards
         {
+            if (cats.Length == 0) return;
             CategoryId += direction;
             CategoryId %= cats.Length;
             if (CategoryId < 0) CategoryId += cats.Length; // fix modulo on negatives

--- a/ShiftOS.WinForms/HackerCommands.cs
+++ b/ShiftOS.WinForms/HackerCommands.cs
@@ -679,28 +679,13 @@ namespace ShiftOS.WinForms
         [Command("list", description ="Lists all story IDs.")]
         public static bool ListIds()
         {
-            foreach(var exec in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                if(exec.ToLower().EndsWith(".exe") || exec.ToLower().EndsWith(".dll"))
+            foreach(var type in ReflectMan.Types)
+                foreach(var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
                 {
-                    try
-                    {
-                        var asm = Assembly.LoadFile(exec);
-                        {
-                            foreach(var type in asm.GetTypes())
-                            {
-                                foreach(var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
-                                {
-                                    var attr = method.GetCustomAttributes(false).FirstOrDefault(x => x is StoryAttribute);
-                                    if (attr != null)
-                                        Console.WriteLine(" - " + (attr as StoryAttribute).StoryID);
-                                }
-                            }
-                        }
-                    }
-                    catch { }
+                    var attr = method.GetCustomAttributes(false).FirstOrDefault(x => x is StoryAttribute);
+                    if (attr != null)
+                        Console.WriteLine(" - " + (attr as StoryAttribute).StoryID);
                 }
-            }
             return true;
         }
 

--- a/ShiftOS.WinForms/Program.cs
+++ b/ShiftOS.WinForms/Program.cs
@@ -114,53 +114,39 @@ namespace ShiftOS.WinForms
         {
             var defaultList = JsonConvert.DeserializeObject<List<ShiftoriumUpgrade>>(Properties.Resources.Shiftorium);
 
-            foreach(var exe in Directory.GetFiles(Environment.CurrentDirectory))
+            foreach (var type in ReflectMan.Types)
             {
-                if (exe.EndsWith(".exe") || exe.EndsWith(".dll"))
+                var attribs = type.GetCustomAttributes(false);
+                var attrib = attribs.FirstOrDefault(x => x is AppscapeEntryAttribute) as AppscapeEntryAttribute;
+                if (attrib != null)
                 {
-                    try
+                    var upgrade = new ShiftoriumUpgrade
                     {
-                        var asm = Assembly.LoadFile(exe);
-                        foreach (var type in asm.GetTypes())
-                        {
-                            var attrib = type.GetCustomAttributes(false).FirstOrDefault(x => x is AppscapeEntryAttribute) as AppscapeEntryAttribute;
-                            if (attrib != null)
-                            {
-                                var upgrade = new ShiftoriumUpgrade
-                                {
-                                    Id = attrib.Name.ToLower().Replace(" ", "_"),
-                                    Name = attrib.Name,
-                                    Description = attrib.Description,
-                                    Cost = attrib.Cost,
-                                    Category = attrib.Category,
-                                    Dependencies = (string.IsNullOrWhiteSpace(attrib.DependencyString)) ? "appscape_handled_nodisplay" : "appscape_handled_nodisplay;" + attrib.DependencyString
-                                };
-                                defaultList.Add(upgrade);
-                            }
-
-                            var sattrib = type.GetCustomAttributes(false).FirstOrDefault(x => x is StpContents) as StpContents;
-                            if (sattrib != null)
-                            {
-                                var upgrade = new ShiftoriumUpgrade
-                                {
-                                    Id = sattrib.Upgrade,
-                                    Name = sattrib.Name,
-                                    Description = "This is a hidden dummy upgrade for the .stp file installation attribute \"" + sattrib.Name + "\".",
-                                    Cost = 0,
-                                    Category = "If this is shown, there's a bug in the Shiftorium Provider or the user is a supreme Shifter.",
-                                    Dependencies = "dummy_nodisplay"
-                                };
-                                defaultList.Add(upgrade);
-                            }
-
-                        }
-
-
-
-
-                    }
-                    catch { }
+                        Id = attrib.Name.ToLower().Replace(" ", "_"),
+                        Name = attrib.Name,
+                        Description = attrib.Description,
+                        Cost = attrib.Cost,
+                        Category = attrib.Category,
+                        Dependencies = (string.IsNullOrWhiteSpace(attrib.DependencyString)) ? "appscape_handled_nodisplay" : "appscape_handled_nodisplay;" + attrib.DependencyString
+                    };
+                    defaultList.Add(upgrade);
                 }
+
+                var sattrib = attribs.FirstOrDefault(x => x is StpContents) as StpContents;
+                if (sattrib != null)
+                {
+                    var upgrade = new ShiftoriumUpgrade
+                    {
+                        Id = sattrib.Upgrade,
+                        Name = sattrib.Name,
+                        Description = "This is a hidden dummy upgrade for the .stp file installation attribute \"" + sattrib.Name + "\".",
+                        Cost = 0,
+                        Category = "If this is shown, there's a bug in the Shiftorium Provider or the user is a supreme Shifter.",
+                        Dependencies = "dummy_nodisplay"
+                    };
+                    defaultList.Add(upgrade);
+                }
+
             }
             return defaultList;
         }

--- a/ShiftOS.WinForms/ShiftnetSites/AppscapeMain.cs
+++ b/ShiftOS.WinForms/ShiftnetSites/AppscapeMain.cs
@@ -207,33 +207,21 @@ namespace ShiftOS.WinForms.ShiftnetSites
                                 if (result == true)
                                 {
                                     SaveSystem.CurrentSave.Codepoints -= upg.Cost;
-                                    foreach (var exe in Directory.GetFiles(Environment.CurrentDirectory))
+                                    foreach (var type in ReflectMan.Types)
                                     {
-                                        if (exe.EndsWith(".exe") || exe.EndsWith(".dll"))
+                                        var attrib = type.GetCustomAttributes(false).FirstOrDefault(x => x is AppscapeEntryAttribute) as AppscapeEntryAttribute;
+                                        if (attrib != null)
                                         {
-                                            try
+                                            if (attrib.Name == upg.Name)
                                             {
-                                                var asm = Assembly.LoadFile(exe);
-                                                foreach (var type in asm.GetTypes())
-                                                {
-                                                    var attrib = type.GetCustomAttributes(false).FirstOrDefault(x => x is AppscapeEntryAttribute) as AppscapeEntryAttribute;
-                                                    if (attrib != null)
-                                                    {
-                                                        if (attrib.Name == upg.Name)
-                                                        {
-                                                            var installer = new Applications.Installer();
-                                                            var installation = new AppscapeInstallation(upg.Name, attrib.DownloadSize, upg.ID);
-                                                            AppearanceManager.SetupWindow(installer);
-                                                            installer.InitiateInstall(installation);
-                                                            return;
-                                                        }
-                                                    }
-                                                }
+                                                var installer = new Applications.Installer();
+                                                var installation = new AppscapeInstallation(upg.Name, attrib.DownloadSize, upg.ID);
+                                                AppearanceManager.SetupWindow(installer);
+                                                installer.InitiateInstall(installation);
+                                                return;
                                             }
-                                            catch { }
                                         }
                                     }
-
                                 }
                             });
                         }

--- a/ShiftOS.WinForms/ShiftnetSites/MainHomepage.cs
+++ b/ShiftOS.WinForms/ShiftnetSites/MainHomepage.cs
@@ -39,49 +39,30 @@ namespace ShiftOS.WinForms.ShiftnetSites
         {
             //Get the Fundamentals List
             flfundamentals.Controls.Clear();
-            foreach (var exe in Directory.GetFiles(Environment.CurrentDirectory))
+            foreach (var type in Array.FindAll(ReflectMan.Types, t => t.GetInterfaces().Contains(typeof(IShiftnetSite)) && t.BaseType == typeof(UserControl) && Shiftorium.UpgradeAttributesUnlocked(t)))
             {
-                if (exe.EndsWith(".exe") || exe.EndsWith(".dll"))
+                var attrs = type.GetCustomAttributes(false);
+                var attribute = attrs.FirstOrDefault(x => x is ShiftnetSiteAttribute) as ShiftnetSiteAttribute;
+                if (attribute != null)
                 {
-                    try
+                    if (attrs.OfType<ShiftnetFundamentalAttribute>().Any())
                     {
-                        var asm = Assembly.LoadFile(exe);
-                        foreach (var type in asm.GetTypes())
+                        var dash = new Label();
+                        dash.Text = " - ";
+                        dash.AutoSize = true;
+                        flfundamentals.Controls.Add(dash);
+                        dash.Show();
+                        var link = new LinkLabel();
+                        link.Text = attribute.Name;
+                        link.Click += (o, a) =>
                         {
-                            if (type.GetInterfaces().Contains(typeof(IShiftnetSite)))
-                            {
-                                if (type.BaseType == typeof(UserControl))
-                                {
-                                    var attribute = type.GetCustomAttributes(false).FirstOrDefault(x => x is ShiftnetSiteAttribute) as ShiftnetSiteAttribute;
-                                    if (attribute != null)
-                                    {
-                                        if (Shiftorium.UpgradeAttributesUnlocked(type))
-                                        {
-                                            if (type.GetCustomAttributes(false).FirstOrDefault(x => x is ShiftnetFundamentalAttribute) != null)
-                                            {
-                                                var dash = new Label();
-                                                dash.Text = " - ";
-                                                dash.AutoSize = true;
-                                                flfundamentals.Controls.Add(dash);
-                                                dash.Show();
-                                                var link = new LinkLabel();
-                                                link.Text = attribute.Name;
-                                                link.Click += (o, a) =>
-                                                {
-                                                    GoToUrl?.Invoke(attribute.Url);
-                                                };
-                                                flfundamentals.Controls.Add(link);
-                                                flfundamentals.SetFlowBreak(link, true);
-                                                link.Show();
-                                                link.LinkColor = SkinEngine.LoadedSkin.ControlTextColor;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                            GoToUrl?.Invoke(attribute.Url);
+                        };
+                        flfundamentals.Controls.Add(link);
+                        flfundamentals.SetFlowBreak(link, true);
+                        link.Show();
+                        link.LinkColor = SkinEngine.LoadedSkin.ControlTextColor;
                     }
-                    catch { }
                 }
             }
 

--- a/ShiftOS.WinForms/ShiftnetSites/ShiftSoft_Ping.cs
+++ b/ShiftOS.WinForms/ShiftnetSites/ShiftSoft_Ping.cs
@@ -34,53 +34,38 @@ namespace ShiftOS.WinForms.ShiftnetSites
         public void SetupListing()
         {
             fllist.Controls.Clear();
-            foreach(var exec in Directory.GetFiles(Environment.CurrentDirectory))
+            foreach (var type in Array.FindAll(ReflectMan.Types, t => t.GetInterfaces().Contains(typeof(IShiftnetSite))))
             {
-                if(exec.ToLower().EndsWith(".exe") || exec.ToLower().EndsWith(".dll"))
+                var attr = type.GetCustomAttributes(false).FirstOrDefault(x => x is ShiftnetSiteAttribute) as ShiftnetSiteAttribute;
+                if (attr != null)
                 {
-                    try
+                    if (attr.Url.StartsWith("shiftnet/"))
                     {
-                        var asm = Assembly.LoadFile(exec);
-                        var types = asm.GetTypes();
-                        foreach (var type in types)
+                        var lnk = new LinkLabel();
+                        lnk.LinkColor = SkinEngine.LoadedSkin.ControlTextColor;
+                        lnk.Text = attr.Name;
+                        var desc = new Label();
+                        desc.AutoSize = true;
+                        lnk.AutoSize = true;
+                        desc.MaximumSize = new Size(this.Width / 3, 0);
+                        desc.Text = attr.Description;
+                        desc.Padding = new Padding
                         {
-                            if (type.GetInterfaces().Contains(typeof(IShiftnetSite)))
-                            {
-                                var attr = type.GetCustomAttributes(false).FirstOrDefault(x => x is ShiftnetSiteAttribute) as ShiftnetSiteAttribute;
-                                if (attr != null)
-                                {
-                                    if (attr.Url.StartsWith("shiftnet/"))
-                                    {
-                                        var lnk = new LinkLabel();
-                                        lnk.LinkColor = SkinEngine.LoadedSkin.ControlTextColor;
-                                        lnk.Text = attr.Name;
-                                        var desc = new Label();
-                                        desc.AutoSize = true;
-                                        lnk.AutoSize = true;
-                                        desc.MaximumSize = new Size(this.Width / 3, 0);
-                                        desc.Text = attr.Description;
-                                        desc.Padding = new Padding
-                                        {
-                                            Bottom = 25,
-                                            Top = 0,
-                                            Left = 10,
-                                            Right = 10
-                                        };
-                                        lnk.Click += (o, a) =>
-                                        {
-                                            GoToUrl?.Invoke(attr.Url);
-                                        };
-                                        fllist.Controls.Add(lnk);
-                                        fllist.Controls.Add(desc);
-                                        ControlManager.SetupControls(lnk);
-                                        lnk.Show();
-                                        desc.Show();
-                                    }
-                                }
-                            }
-                        }
+                            Bottom = 25,
+                            Top = 0,
+                            Left = 10,
+                            Right = 10
+                        };
+                        lnk.Click += (o, a) =>
+                        {
+                            GoToUrl?.Invoke(attr.Url);
+                        };
+                        fllist.Controls.Add(lnk);
+                        fllist.Controls.Add(desc);
+                        ControlManager.SetupControls(lnk);
+                        lnk.Show();
+                        desc.Show();
                     }
-                    catch { }
                 }
             }
         }

--- a/ShiftOS.WinForms/WidgetManager.cs
+++ b/ShiftOS.WinForms/WidgetManager.cs
@@ -16,36 +16,12 @@ namespace ShiftOS.WinForms
     {
         public static Dictionary<DesktopWidgetAttribute, Type> GetAllWidgetTypes()
         {
-            Dictionary<DesktopWidgetAttribute, Type> types = new Dictionary<WinForms.DesktopWidgetAttribute, Type>();
-            foreach(var exe in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                if(exe.EndsWith(".exe") || exe.EndsWith(".dll"))
-                {
-                    try
-                    {
-                        var asm = Assembly.LoadFile(exe);
-                        foreach(var type in asm.GetTypes())
-                        {
-                            if (type.GetInterfaces().Contains(typeof(IDesktopWidget)))
-                            {
-                                if (Shiftorium.UpgradeAttributesUnlocked(type))
-                                {
-                                    foreach (var attrib in type.GetCustomAttributes(false))
-                                    {
-                                        if (attrib is DesktopWidgetAttribute)
-                                        {
-                                            var dw = attrib as DesktopWidgetAttribute;
-                                            types.Add(dw, type);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    catch { }
-                }
-            }
-            return types;
+            var ret = new Dictionary<DesktopWidgetAttribute, Type>();
+            var types = Array.FindAll(ReflectMan.Types, t => t.GetInterfaces().Contains(typeof(IDesktopWidget)) && Shiftorium.UpgradeAttributesUnlocked(t));
+            foreach (var type in types)
+                foreach (var attrib in Array.FindAll(type.GetCustomAttributes(false), a =>  a is DesktopWidgetAttribute))
+                        ret.Add(attrib as DesktopWidgetAttribute, type);
+            return ret;
         }
 
         internal static void SaveDetails(Type type, WidgetDetails location)

--- a/ShiftOS_TheReturn/AppLauncherDaemon.cs
+++ b/ShiftOS_TheReturn/AppLauncherDaemon.cs
@@ -63,55 +63,16 @@ namespace ShiftOS.Engine
         {
             List<LauncherItem> win = new List<LauncherItem>();
             
-            foreach (var asmExec in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
+            foreach (var type in Array.FindAll(ReflectMan.Types, t => t.GetInterfaces().Contains(typeof(IShiftOSWindow)) && Shiftorium.UpgradeAttributesUnlocked(t)))
             {
-                if (asmExec.EndsWith(".dll") | asmExec.EndsWith(".exe"))
-                {
-                    try
-                    {
-                        var asm = Assembly.LoadFrom(asmExec);
-
-                        if (asm.GetReferencedAssemblies().Contains("ShiftOS.Engine") || asm.FullName.Contains("ShiftOS.Engine"))
+                foreach (var attr in type.GetCustomAttributes(false))
+                    if (!(attr is MultiplayerOnlyAttribute && !KernelWatchdog.MudConnected))
+                        if (attr is LauncherAttribute)
                         {
-                            foreach (var type in asm.GetTypes())
-                            {
-                                if (type.GetInterfaces().Contains(typeof(IShiftOSWindow)))
-                                {
-                                    bool isAllowed = true;
-                                    foreach (var attr in type.GetCustomAttributes(false))
-                                    {
-                                        if(attr is MultiplayerOnlyAttribute)
-                                        {
-                                            if(KernelWatchdog.MudConnected == false)
-                                            {
-                                                isAllowed = false;
-
-                                            }
-                                        }
-                                        if (isAllowed == true)
-                                        {
-                                            if (attr is LauncherAttribute)
-                                            {
-                                                if (Shiftorium.UpgradeAttributesUnlocked(type))
-                                                {
-                                                    var launch = attr as LauncherAttribute;
-                                                    if (launch.UpgradeInstalled)
-                                                    {
-                                                        win.Add(new LauncherItem { DisplayData = launch, LaunchType = type });
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            var launch = attr as LauncherAttribute;
+                            if (launch.UpgradeInstalled)
+                                win.Add(new LauncherItem { DisplayData = launch, LaunchType = type });
                         }
-                    }
-                    catch
-                    {
-
-                    }
-                }
             }
 
             foreach(var file in Utils.GetFiles(Paths.GetPath("applauncher")))

--- a/ShiftOS_TheReturn/AppearanceManager.cs
+++ b/ShiftOS_TheReturn/AppearanceManager.cs
@@ -58,25 +58,7 @@ namespace ShiftOS.Engine
         //HEY LETS FIND THE WINDOWS
         public static IEnumerable<Type> GetAllWindowTypes()
         {
-            List<Type> types = new List<Type>();
-            foreach(var file in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                // hey if a thing is an exe or a dll show up plz kthx
-                if(file.EndsWith(".exe") || file.EndsWith(".dll"))
-                {
-                    try
-                    {
-                        var asm = Assembly.LoadFile(file);
-                        foreach(var type in asm.GetTypes())
-                        {
-                            if (type.GetInterfaces().Contains(typeof(IShiftOSWindow)))
-                                types.Add(type);
-                        }
-                    }
-                    catch { }
-                }
-            }
-            return types;
+            return Array.FindAll(ReflectMan.Types, t => t.GetInterfaces().Contains(typeof(IShiftOSWindow)));
         }
 
         // hey you know that window we just made appear? well give it its title

--- a/ShiftOS_TheReturn/NotificationDaemon.cs
+++ b/ShiftOS_TheReturn/NotificationDaemon.cs
@@ -41,26 +41,7 @@ namespace ShiftOS.Engine
         /// <returns>An array of <see cref="Type"/>s containing the found objects.</returns>
         public static Type[] GetAllStatusIcons()
         {
-            List<Type> lst = new List<Type>();
-            foreach(var exec in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                if(exec.ToLower().EndsWith(".exe") || exec.ToLower().EndsWith(".dll"))
-                {
-                    try
-                    {
-                        var asm = Assembly.LoadFile(exec);
-                        foreach(var type in asm.GetTypes().Where(x => x.GetInterfaces().Contains(typeof(IStatusIcon))))
-                        {
-                            if (Shiftorium.UpgradeAttributesUnlocked(type))
-                            {
-                                lst.Add(type);
-                            }
-                        }
-                    }
-                    catch { }
-                }
-            }
-            return lst.ToArray();
+            return Array.FindAll(ReflectMan.Types, x => x.GetInterfaces().Contains(typeof(IStatusIcon)) && Shiftorium.UpgradeAttributesUnlocked(x));
         }
 
 

--- a/ShiftOS_TheReturn/ReflectMan.cs
+++ b/ShiftOS_TheReturn/ReflectMan.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * MIT License
+ * 
+ * Copyright (c) 2017 Michael VanOverbeek and ShiftOS devs
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShiftOS.Engine
+{
+    public static class ReflectMan
+    {
+        private static Assembly[] asms = null;
+        public static Assembly[] Asms
+        {
+            get
+            {
+                if (asms == null)
+                    LoadAssemblies();
+                return asms;
+            }
+        }
+
+        private static Type[] types = null;
+        public static Type[] Types
+        {
+            get
+            {
+                if (types == null)
+                    FindTypes();
+                return types;
+            }
+        }
+
+        private static void LoadAssemblies()
+        {
+            var ret = new List<Assembly>();
+            foreach (var exe in Array.FindAll(System.IO.Directory.GetFiles(Environment.CurrentDirectory), n => n.EndsWith(".exe") || n.EndsWith(".dll")))
+                try
+                {
+                    var asm = Assembly.LoadFile(exe);
+                    if (asm.GetReferencedAssemblies().Contains("ShiftOS.Engine") || asm.FullName.Contains("ShiftOS.Engine"))
+                        ret.Add(asm);
+                }
+                catch { } // probably not a managed assembly
+            asms = ret.ToArray();
+        }
+
+        private static void FindTypes()
+        {
+            var ret = new List<Type>();
+            foreach (var asm in Asms)
+                ret.AddRange(asm.GetTypes());
+            types = ret.ToArray();
+        }
+    }
+}

--- a/ShiftOS_TheReturn/ServerManager.cs
+++ b/ShiftOS_TheReturn/ServerManager.cs
@@ -110,32 +110,19 @@ Ping: {ServerManager.DigitalSocietyPing} ms
         {
             string[] split = msg.GUID.Split('|');
             bool finished = false;
-            foreach (var exec in Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                if(exec.ToLower().EndsWith(".exe") || exec.ToLower().EndsWith(".dll"))
+            if (split[0] == SaveSystem.CurrentSave.SystemName)
+                foreach(var type in Array.FindAll(ReflectMan.Types, x => x.GetInterfaces().Contains(typeof(Server)) && Shiftorium.UpgradeAttributesUnlocked(x)))
                 {
-                    try
+                    var attrib = type.GetCustomAttributes().FirstOrDefault(x => x is ServerAttribute) as ServerAttribute;
+                    if(attrib != null)
                     {
-                        var asm = Assembly.LoadFile(exec);
-                        foreach(var type in asm.GetTypes().Where(x => x.GetInterfaces().Contains(typeof(Server))))
+                        if(split[1] == attrib.Port.ToString())
                         {
-                            var attrib = type.GetCustomAttributes().FirstOrDefault(x => x is ServerAttribute) as ServerAttribute;
-                            if(attrib != null)
-                            {
-                                if(split[0] == SaveSystem.CurrentSave.SystemName && split[1] == attrib.Port.ToString())
-                                {
-                                    if (Shiftorium.UpgradeAttributesUnlocked(type))
-                                    {
-                                        type.GetMethods(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(x => x.Name == "MessageReceived")?.Invoke(Activator.CreateInstance(type), null);
-                                        finished = true;
-                                    }
-                                }
-                            }
+                            type.GetMethods(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(x => x.Name == "MessageReceived")?.Invoke(Activator.CreateInstance(type), null);
+                            finished = true;
                         }
                     }
-                    catch { }
                 }
-            }
             if (finished == false)
             {
                 Forward(split[2], "Error", $"{split[0]}:{split[1]}: connection refused");

--- a/ShiftOS_TheReturn/ShiftOS.Engine.csproj
+++ b/ShiftOS_TheReturn/ShiftOS.Engine.csproj
@@ -123,6 +123,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ReflectMan.cs" />
     <Compile Include="SaveSystem.cs" />
     <Compile Include="Scripting.cs" />
     <Compile Include="Server.cs" />

--- a/ShiftOS_TheReturn/Shiftorium.cs
+++ b/ShiftOS_TheReturn/Shiftorium.cs
@@ -214,23 +214,11 @@ namespace ShiftOS.Engine
         {
             upgDb = new List<ShiftoriumUpgrade>();
             //Now we probe for ShiftoriumUpgradeAttributes for mods.
-            foreach (var file in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
-            {
-                if (file.EndsWith(".exe") || file.EndsWith(".dll"))
-                {
-                    try
-                    {
-                        var asm = Assembly.LoadFile(file);
-                        foreach (var type in asm.GetTypes())
+                        foreach (var type in ReflectMan.Types)
                         {
                             if (type.GetInterfaces().Contains(typeof(IShiftoriumProvider)))
-                            {
-                                if (type.GetCustomAttributes().FirstOrDefault(x => x is ShiftoriumProviderAttribute) != null)
-                                {
-                                    var _p = Activator.CreateInstance(type, null) as IShiftoriumProvider;
-                                    upgDb.AddRange(_p.GetDefaults());
-                                }
-                            }
+                                if (type.GetCustomAttributes().Any(x => x is ShiftoriumProviderAttribute))
+                                    upgDb.AddRange((Activator.CreateInstance(type, null) as IShiftoriumProvider).GetDefaults());
 
 
                             ShiftoriumUpgradeAttribute attrib = type.GetCustomAttributes(false).FirstOrDefault(x => x is ShiftoriumUpgradeAttribute) as ShiftoriumUpgradeAttribute;
@@ -310,10 +298,6 @@ namespace ShiftOS.Engine
                             }
 
                         }
-                    }
-                    catch { }
-                }
-            }
 
 
 

--- a/ShiftOS_TheReturn/Skinning.cs
+++ b/ShiftOS_TheReturn/Skinning.cs
@@ -242,38 +242,16 @@ namespace ShiftOS.Engine
         /// <returns>The resulting icon image.</returns>
         public static Image GetDefaultIcon(string id)
         {
-            if (_iconProber == null)
+            if (_iconProber != null)
             {
-                return new Bitmap(16, 16);
-            }
-            else
-            {
-                foreach (var f in System.IO.Directory.GetFiles(Environment.CurrentDirectory))
+                foreach (var type in Array.FindAll(ReflectMan.Types, t => t.Name == id))
                 {
-                    if (f.EndsWith(".exe") || f.EndsWith(".dll"))
-                    {
-                        try
-                        {
-                            var asm = Assembly.LoadFile(f);
-                            foreach (var type in asm.GetTypes())
-                            {
-                                if (type.Name == id)
-                                {
-                                    foreach (var attr in type.GetCustomAttributes(true))
-                                    {
-                                        if (attr is DefaultIconAttribute)
-                                        {
-                                            return _iconProber.GetIcon(attr as DefaultIconAttribute);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        catch { }
-                    }
+                    var attr = Array.Find(type.GetCustomAttributes(true), a => a is DefaultIconAttribute);
+                    if (attr != null)
+                        return _iconProber.GetIcon(attr as DefaultIconAttribute);
                 }
-                return new Bitmap(16, 16);
             }
+            return new Bitmap(16, 16);
         }
 
         /// <summary>


### PR DESCRIPTION
Refactored every part in the code that used that damn foreach loop.
All assemblies are now loaded on startup into an array, and the
results of GetType() on each are concatenated into another array.
The parts of the code that were loading the assemblies and scanning
them themselves now look to ReflectMan.Types, and all disk I/O is
limited to the first time ReflectMan is accessed. While I was there
I also replaced some other foreach loops with array comprehensions
and such to speed things up - there is a noticeable improvement.

It doesn't seem to have broken anything, but I'd appreciate if
someone could do more stress testing for me.